### PR TITLE
Enable lizard song replay with themed button

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,30 +21,27 @@ const App: React.FC = () => {
     };
   }, [audio]);
 
-  const togglePlayPause = useCallback(() => {
-    if (playState === PlayState.PLAYING) {
-      audio.pause();
-      setPlayState(PlayState.PAUSED);
-    } else {
-      audio.play().catch(error => {
+  const playFromStart = useCallback(() => {
+    audio.pause();
+    audio.currentTime = 0;
+    audio
+      .play()
+      .catch(error => {
         console.error("Error playing audio:", error);
-        // Handle autoplay policy restrictions if necessary
         setPlayState(PlayState.PAUSED);
       });
-      setPlayState(PlayState.PLAYING);
-    }
-  }, [audio, playState]);
+    setPlayState(PlayState.PLAYING);
+  }, [audio]);
 
   return (
     <main className="bg-slate-900 text-white min-h-screen flex items-center justify-center antialiased">
       <div className="relative flex items-center justify-center">
-        <div 
-          className={`absolute rounded-full bg-pink-500/30 blur-3xl transition-transform duration-1000 ${playState === PlayState.PLAYING ? 'animate-pulse scale-125' : 'scale-100'}`}
+        <div
+          className={`absolute rounded-full bg-green-500/30 blur-3xl transition-transform duration-1000 ${playState === PlayState.PLAYING ? 'animate-pulse scale-125' : 'scale-100'}`}
           style={{ width: '150px', height: '150px' }}
         />
-        <PlayButton 
-          playState={playState} 
-          onClick={togglePlayPause} 
+        <PlayButton
+          onClick={playFromStart}
         />
       </div>
     </main>

--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -1,25 +1,18 @@
 
 import React from 'react';
-import { PlayState } from '../types';
-import { PlayIcon, PauseIcon } from '../constants/icons';
 
 interface PlayButtonProps {
-  playState: PlayState;
   onClick: () => void;
 }
 
-export const PlayButton: React.FC<PlayButtonProps> = ({ playState, onClick }) => {
+export const PlayButton: React.FC<PlayButtonProps> = ({ onClick }) => {
   return (
     <button
       onClick={onClick}
-      aria-label={playState === PlayState.PLAYING ? 'Pause song' : 'Play song'}
-      className="relative z-10 flex items-center justify-center w-32 h-32 md:w-40 md:h-40 bg-pink-500 rounded-full shadow-lg shadow-pink-500/30 hover:bg-pink-600 active:bg-pink-700 transform hover:scale-105 active:scale-100 transition-all duration-300 ease-in-out focus:outline-none focus:ring-4 focus:ring-pink-400 focus:ring-opacity-75"
+      aria-label="Play lizard song"
+      className="relative z-10 flex items-center justify-center w-32 h-32 md:w-40 md:h-40 bg-green-500 rounded-full shadow-lg shadow-green-500/30 hover:bg-green-600 active:bg-green-700 transform hover:scale-105 active:scale-100 transition-all duration-300 ease-in-out focus:outline-none focus:ring-4 focus:ring-green-400 focus:ring-opacity-75 text-6xl"
     >
-      {playState === PlayState.PLAYING ? (
-        <PauseIcon className="w-16 h-16 text-white" />
-      ) : (
-        <PlayIcon className="w-16 h-16 text-white" />
-      )}
+      🦎
     </button>
   );
 };


### PR DESCRIPTION
## Summary
- Restart audio from the beginning each time the button is clicked
- Style button with green lizard emoji and matching glow

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6890e4494c94832892ea842568f8ba41